### PR TITLE
Turn new angular templating off by default in html

### DIFF
--- a/js/src/cli.js
+++ b/js/src/cli.js
@@ -199,7 +199,7 @@ var path = require('path'),
         // no shorthand for "config"
         // no shorthand for "editorconfig"
         // no shorthand for "indent_empty_lines"
-        // not shorthad for "templating"
+        // no shorthad for "templating"
     });
 
 function verifyExists(fullPath) {
@@ -370,7 +370,8 @@ function usage(err) {
         '                                    [first newline in file, otherwise "\\n]',
         '  -n, --end-with-newline            End output with newline',
         '  --indent-empty-lines              Keep indentation on empty lines',
-        '  --templating                      List of templating languages (auto,none,django,erb,handlebars,php,smarty,angular) ["auto"] auto = none in JavaScript, all in html',
+        '  --templating                      List of templating languages (auto,none,angular,django,erb,handlebars,php,smarty)',
+        '                                    ["auto", auto = none in JavaScript, auto = all except angular in html (and inline javascript/css)]',
         '  --editorconfig                    Use EditorConfig to set up the options'
     ];
 
@@ -409,7 +410,7 @@ function usage(err) {
             msg.push('  -U, --unformatted                 List of tags (defaults to inline) that should not be reformatted');
             msg.push('  -T, --content_unformatted         List of tags (defaults to pre) whose content should not be reformatted');
             msg.push('  -E, --extra_liners                List of tags (defaults to [head,body,/html] that should have an extra newline');
-            msg.push('  --unformatted_content_delimiter    Keep text content together between this string [""]');
+            msg.push('  --unformatted_content_delimiter   Keep text content together between this string [""]');
             break;
         case "css":
             msg.push('  -b, --brace-style                       [collapse|expand] ["collapse"]');

--- a/js/src/core/options.js
+++ b/js/src/core/options.js
@@ -68,9 +68,9 @@ function Options(options, merge_child_field) {
   this.indent_empty_lines = this._get_boolean('indent_empty_lines');
 
   // valid templating languages ['django', 'erb', 'handlebars', 'php', 'smarty', 'angular']
-  // For now, 'auto' = all off for javascript, all on for html (and inline javascript).
+  // For now, 'auto' = all off for javascript, all except angular on for html (and inline javascript/css).
   // other values ignored
-  this.templating = this._get_selection_list('templating', ['auto', 'none', 'django', 'erb', 'handlebars', 'php', 'smarty', 'angular'], ['auto']);
+  this.templating = this._get_selection_list('templating', ['auto', 'none', 'angular', 'django', 'erb', 'handlebars', 'php', 'smarty'], ['auto']);
 }
 
 Options.prototype._get_array = function(name, default_value) {

--- a/js/src/html/options.js
+++ b/js/src/html/options.js
@@ -33,7 +33,7 @@ var BaseOptions = require('../core/options').Options;
 function Options(options) {
   BaseOptions.call(this, options, 'html');
   if (this.templating.length === 1 && this.templating[0] === 'auto') {
-    this.templating = ['django', 'erb', 'handlebars', 'php', 'angular'];
+    this.templating = ['django', 'erb', 'handlebars', 'php'];
   }
 
   this.indent_inner_html = this._get_boolean('indent_inner_html');

--- a/python/jsbeautifier/core/options.py
+++ b/python/jsbeautifier/core/options.py
@@ -77,11 +77,11 @@ class Options:
         self.indent_empty_lines = self._get_boolean("indent_empty_lines")
 
         # valid templating languages ['django', 'erb', 'handlebars', 'php', 'smarty', 'angular']
-        # For now, 'auto' = all off for javascript, all on for html (and inline javascript).
+        # For now, 'auto' = all off for javascript, all except angular on for html (and inline javascript/css).
         # other values ignored
         self.templating = self._get_selection_list(
             "templating",
-            ["auto", "none", "django", "erb", "handlebars", "php", "smarty", "angular"],
+            ["auto", "none", "angular", "django", "erb", "handlebars", "php", "smarty"],
             ["auto"],
         )
 

--- a/python/jsbeautifier/tests/core/test_options.py
+++ b/python/jsbeautifier/tests/core/test_options.py
@@ -102,15 +102,13 @@ class TestOptions(unittest.TestCase):
 
     def test__get_selection_list(self):
         # should raise error with empty selection
-        with self.assertRaisesRegexp(
-            ValueError, "Selection list cannot" + " be empty."
-        ):
+        with self.assertRaisesRegex(ValueError, "Selection list cannot" + " be empty."):
             Options()._get_selection_list("a", [])
         # should raise error with invalid default
-        with self.assertRaisesRegexp(ValueError, "Invalid Default Value!"):
+        with self.assertRaisesRegex(ValueError, "Invalid Default Value!"):
             Options()._get_selection_list("a", ["a", "b"], ["c"])
         # should raise error with invalid option
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             ValueError, "^Invalid Option Value:" + " The option"
         ):
             Options({"a": ["c", "d"]})._get_selection_list("a", ["a", "b"], ["a", "b"])
@@ -120,7 +118,7 @@ class TestOptions(unittest.TestCase):
 
     def test__get_selection(self):
         # should raise error with multiple selection
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             ValueError, "^Invalid Option" + " Value: The option"
         ):
             Options({"a": ["a", "b"]})._get_selection("a", ["a", "b"], ["a"])

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -4238,6 +4238,43 @@ exports.test_data = {
         '    </div>',
         '}'
       ]
+    }, {
+      comment: 'CSS @media should remain unchanged',
+      // This behavior is currently incorrect. This codifies the way it fails.
+      // unchanged: [
+      //   '<style type="text/css">',
+      //   '    @media only screen and (min-width:480px) {',
+      //   '        .mj-column-per-100 {',
+      //   '            width: 100% !important;',
+      //   '            max-width: 100%;',
+      //   '        }',
+      //   '    }',
+      //   '</style>'
+      // ]
+      input: [
+        '<style type="text/css">',
+        '    @media only screen and (min-width:480px) {',
+        '        .mj-column-per-100 {',
+        '            width: 100% !important;',
+        '            max-width: 100%;',
+        '        }',
+        '    }',
+        '</style>'
+      ],
+      output: [
+        '<style type="text/css">',
+        '@media only screen and (min-width:480px) {',
+        '        .mj-column-per-100',
+        '        {',
+        '        width:',
+        '        100%',
+        '        !important;',
+        '        max-width:',
+        '        100%;',
+        '}',
+        '    }',
+        '</style>'
+      ]
     }]
   }, {
     name: "No indenting for angular control flow should be done if indent_handlebars is false",
@@ -4328,6 +4365,18 @@ exports.test_data = {
         '    </p>',
         '    }',
         '</div>'
+      ]
+    }, {
+      comment: 'CSS @media should remain unchanged',
+      unchanged: [
+        '<style type="text/css">',
+        '    @media only screen and (min-width:480px) {',
+        '        .mj-column-per-100 {',
+        '            width: 100% !important;',
+        '            max-width: 100%;',
+        '        }',
+        '    }',
+        '</style>'
       ]
     }]
   }, {


### PR DESCRIPTION
# Description
- [x] Source branch in your fork has meaningful name (not `main`)
The new angular templating caused unintended side-effects when turned on by default.  This changes it by off by default.


Fixes #2246 



# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [ ] JavaScript implementation
- [ ] Python implementation (NA if HTML beautifier)
- [ ] Added Tests to data file(s)
- [ ] Added command-line option(s) (NA if
- [ ] README.md documents new feature/option(s)

