### PR TITLE
fix escape_strings issue

### DIFF
--- a/js/src/javascript/tokenizer.js
+++ b/js/src/javascript/tokenizer.js
@@ -359,8 +359,6 @@ Tokenizer.prototype._read_string = function(c) {
       resulting_string += this._input.next();
     }
 
-    resulting_string = resulting_string.replace(acorn.allLineBreaks, '\n');
-
     return this._create_token(TOKEN.STRING, resulting_string);
   }
 

--- a/python/jsbeautifier/javascript/tokenizer.py
+++ b/python/jsbeautifier/javascript/tokenizer.py
@@ -335,8 +335,6 @@ class Tokenizer(BaseTokenizer):
             if self._input.peek() == c:
                 resulting_string += self._input.next()
 
-            resulting_string = re.sub(self.acorn.allLineBreaks, "\n", resulting_string)
-
             return self._create_token(TOKEN.STRING, resulting_string)
 
         return None


### PR DESCRIPTION
# Description

firstly, the '\n' is not correctly escaped (should be '\\n'), which causes a syntax error in the beautified code, because an actual new line is inserted instead of \n.

additionally, even if it were correctly escaped, it would still cause problems as while the characters look similar, they are treated as not equal by javascript.
```js
let object = {};
object['\u2028'] = "this is '\\u2028'";
object['\n'] = "this is '\\n'";
console.log(object['\u2028']) // this is '\u2028'
```
if it were replaced by '\n', it would become
```js
let object = {};
object['\n'] = "this is '\\u2028'";
object['\n'] = "this is '\\n'";
console.log(object['\n']) // this is '\n'
```
which changes the behavior of the code


because of these issues, its best to leave certain escaped characters the way they are.

Fixes Issue: https://github.com/beautifier/js-beautify/issues/2267



# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [ ] JavaScript implementation
- [ ] Python implementation (NA if HTML beautifier)
- [ ] Added Tests to data file(s)
- [ ] Added command-line option(s) (NA if
- [ ] README.md documents new feature/option(s)

