### PR TITLE
fix(cli): templating arguments getops

### DIFF
--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -190,7 +190,7 @@ def main():
                 "space-in-empty-paren",
                 "space-in-paren",
                 "stdin",
-                "templating",
+                "templating=",
                 "unescape-strings",
                 "usage",
                 "version",


### PR DESCRIPTION
# Description
- [x] Source branch in your fork has meaningful name (not `main`)


Fixes Issue: 

The `templating` CLI parameter requires an argument for the template to use, but this cannot be passed since the `getops` definition is missing the `=` sign.


# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [ ] JavaScript implementation
- [ ] Python implementation (NA if HTML beautifier)
- [ ] Added Tests to data file(s)
- [ ] Added command-line option(s) (NA if
- [ ] README.md documents new feature/option(s)

