### PR TITLE
one-line bug in templatablepattern.py

### DIFF
--- a/python/jsbeautifier/core/templatablepattern.py
+++ b/python/jsbeautifier/core/templatablepattern.py
@@ -115,7 +115,7 @@ class TemplatablePattern(Pattern):
             next = self._read_template()
 
         if self._until_after:
-            result += self._input.readUntilAfter(self._until_after)
+            result += self._input.readUntilAfter(self._until_pattern)
 
         return result
 


### PR DESCRIPTION
# Description
- [ -] Source branch in your fork has meaningful name (not `main`)


Fixes Issue: 

The templatablepattern.py contained the bug:
```python
    def read(self):
        if self._until_after:
            result += self._input.readUntilAfter(self._until_after) # should be self._until_pattern
```

the self._until_after is bool flag, while the `readUntilAfter` accepts the regexp.
The same code in templatablepattern.js uses the this._until_pattern correctly.

# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [ ] JavaScript implementation
- [- ] Python implementation (NA if HTML beautifier)
- [ ] Added Tests to data file(s)
- [ ] Added command-line option(s) (NA if
- [ ] README.md documents new feature/option(s)

