### PR TITLE
pinned setuptools version to avoid v72 since it removed a feature we're using to build the package

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+# pinned at v71 since v72 removed the test command https://setuptools.pypa.io/en/stable/history.html#v72-0-0
+requires = ["setuptools==71.1.0"]
+
 [tool.black]
 target-version = ['py33', 'py36', 'py37', 'py38']
 exclude = '''


### PR DESCRIPTION
# Description
- [x] Source branch in your fork has meaningful name (not `main`)

Fix for https://github.com/beautifier/js-beautify/issues/2301 .The current package is broken because of unpinned setuptools version



I believe we're hitting this line of the `pip` source code which is using a default `setuptools` version:
https://github.com/pypa/pip/blob/8c7df92eca1d927bb441a6b15e92966ee553aca9/src/pip/_internal/pyproject.py#L132

So this PR avoids that code path by fixing setuptools to `71.1.0` (the latest release before 72.0.0)