### PR TITLE
GitHub Action to pip install cssbeautifier and jsbeautifier

### DIFF
--- a/.github/workflows/pip_install.yml
+++ b/.github/workflows/pip_install.yml
@@ -1,0 +1,22 @@
+name: pip_install
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+jobs:
+  pip_install:
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          - cssbeautifier
+          - jsbeautifier
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.x
+    - run: pip install --upgrade pip
+    - run: pip install ${{ matrix.module }}


### PR DESCRIPTION
These are broken by the the new version of `setuptools`...

https://setuptools.pypa.io/en/stable/history.html#v72-0-0
* pypa/setuptools#931
    * pypa/setuptools#4458

# Description
- [x] Source branch in your fork has meaningful name (not `main`)


Fixes Issue: 



# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [ ] JavaScript implementation
- [x] Python implementation (NA if HTML beautifier)
- [ ] Added Tests to data file(s)
- [ ] Added command-line option(s) (NA if
- [ ] README.md documents new feature/option(s)

