### PR TITLE
Remove obsolete setuptools test integration

### DIFF
--- a/python/setup-css.py
+++ b/python/setup-css.py
@@ -1,31 +1,7 @@
 #!/usr/bin/env python
 
-import os
-import sys
-
 from setuptools import setup
 from cssbeautifier.__version__ import __version__
-
-from setuptools.command.test import test as TestCommand
-
-DIR_CSS = "cssbeautifier/tests/"
-
-
-class PyTestCSS(TestCommand):
-    user_options = [("pytest-args=", "a", "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = ["--assert=plain"] + [
-            DIR + x for x in os.listdir(DIR) if x.endswith(".py") and x[0] not in "._"
-        ]
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
 
 
 setup(
@@ -45,6 +21,4 @@ setup(
     ],
     install_requires=["jsbeautifier", "six>=1.13.0", "editorconfig>=0.12.2"],
     license="MIT",
-    test_suite="pytest.collector",
-    cmdclass={"test": PyTestCSS},
 )

--- a/python/setup-js.py
+++ b/python/setup-js.py
@@ -1,31 +1,7 @@
 #!/usr/bin/env python
 
-import os
-import sys
-
 from setuptools import setup
 from jsbeautifier.__version__ import __version__
-
-from setuptools.command.test import test as TestCommand
-
-DIR = "jsbeautifier/tests/"
-
-
-class PyTest(TestCommand):
-    user_options = [("pytest-args=", "a", "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = ["--assert=plain"] + [
-            DIR + x for x in os.listdir(DIR) if x.endswith(".py") and x[0] not in "._"
-        ]
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
 
 
 setup(
@@ -52,6 +28,4 @@ setup(
     ],
     install_requires=["six>=1.13.0", "editorconfig>=0.12.2"],
     license="MIT",
-    test_suite="pytest.collector",
-    cmdclass={"test": PyTest},
 )


### PR DESCRIPTION
`make pytest` already runs a superset of all the tests run by `python3 setup-css.py test` and `python3 setup-js.py test`.  (The former didn't work anyway due to a typo.)

# Description
- [x] Source branch in your fork has meaningful name (not `main`)


Fixes Issue: #2300, #2301



# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [x] JavaScript implementation
- [x] Python implementation (NA if HTML beautifier)
- [x] Added Tests to data file(s)
- [x] Added command-line option(s) (NA if
- [x] README.md documents new feature/option(s)

