### PR TITLE
Fix show readme.md in PyPi pages

### DIFF
--- a/python/setup-css.py
+++ b/python/setup-css.py
@@ -27,12 +27,16 @@ class PyTestCSS(TestCommand):
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 
+    with open("README.md", "r", encoding="utf-8") as fh:
+        long_description = fh.read()
+
 
 setup(
     name="cssbeautifier",
     version=__version__,
     description="CSS unobfuscator and beautifier.",
-    long_description=("Beautify, unpack or deobfuscate CSS"),
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     author="Liam Newman, Einar Lielmanis, et al.",
     author_email="team@beautifier.io",
     url="https://beautifier.io",

--- a/python/setup-css.py
+++ b/python/setup-css.py
@@ -27,8 +27,6 @@ class PyTestCSS(TestCommand):
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 
-    
-
 
 setup(
     name="cssbeautifier",

--- a/python/setup-css.py
+++ b/python/setup-css.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from pathlib import Path
 import os
 import sys
 
@@ -27,15 +27,14 @@ class PyTestCSS(TestCommand):
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 
-    with open("README.md", "r", encoding="utf-8") as fh:
-        long_description = fh.read()
+    
 
 
 setup(
     name="cssbeautifier",
     version=__version__,
     description="CSS unobfuscator and beautifier.",
-    long_description=long_description,
+    long_description=Path("README.md").read_text(),
     long_description_content_type="text/markdown",
     author="Liam Newman, Einar Lielmanis, et al.",
     author_email="team@beautifier.io",

--- a/python/setup-js.py
+++ b/python/setup-js.py
@@ -26,8 +26,7 @@ class PyTest(TestCommand):
 
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
-
-    
+        
 setup(
     name="jsbeautifier",
     version=__version__,

--- a/python/setup-js.py
+++ b/python/setup-js.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from pathlib import Path
 import os
 import sys
 
@@ -27,13 +27,12 @@ class PyTest(TestCommand):
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 
-    with open("README.md", "r", encoding="utf-8") as fh:
-        long_description = fh.read()
+    
 setup(
     name="jsbeautifier",
     version=__version__,
     description="JavaScript unobfuscator and beautifier.",
-    long_description=long_description,
+    long_description=Path("README.md").read_text(),
     long_description_content_type="text/markdown",
     author="Liam Newman, Einar Lielmanis, et al.",
     author_email="team@beautifier.io",

--- a/python/setup-js.py
+++ b/python/setup-js.py
@@ -27,15 +27,14 @@ class PyTest(TestCommand):
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 
-
+    with open("README.md", "r", encoding="utf-8") as fh:
+        long_description = fh.read()
 setup(
     name="jsbeautifier",
     version=__version__,
     description="JavaScript unobfuscator and beautifier.",
-    long_description=(
-        "Beautify, unpack or deobfuscate JavaScript. "
-        "Handles popular online obfuscators."
-    ),
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     author="Liam Newman, Einar Lielmanis, et al.",
     author_email="team@beautifier.io",
     url="https://beautifier.io",


### PR DESCRIPTION
# Description

PyPi pages changed from plain hardcoded string to render README.md 


Fixes Issue: 



# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [✅] JavaScript implementation
- [✅] Python implementation (NA if HTML beautifier)
- [✅] Added Tests to data file(s)
- [✅] Added command-line option(s) (NA if
- [✅] README.md documents new feature/option(s)

