### PR TITLE
Update glob in package.json to fix security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "config-chain": "^1.1.13",
     "editorconfig": "^1.0.4",
-    "glob": "^10.3.3",
+    "glob": "^11.0.0",
     "js-cookie": "^3.0.5",
     "nopt": "^7.2.0"
   },


### PR DESCRIPTION
Someone will have to run `npm install` prior to merge to update package-lock.json, I'm not currently configured to suck down packages from public npm mirror so I can't do it without mangling your package-lock with private mirror URLs.

This PR fixes security vulnerability listed in this issue: https://github.com/beautifier/js-beautify/issues/2328
