### PR TITLE
drop Python2.7 WIP, trim usage of "six"

### DIFF
--- a/python/jsbeautifier/core/inputscanner.py
+++ b/python/jsbeautifier/core/inputscanner.py
@@ -119,7 +119,7 @@ class InputScanner:
     def get_regexp(self, pattern, match_from=False):
         result = None
         # strings are converted to regexp
-        if isinstance(pattern, self.__six.string_types) and pattern != "":
+        if isinstance(pattern, str) and pattern != "":
             result = re.compile(pattern)
         elif pattern is not None:
             result = re.compile(pattern.pattern)

--- a/python/jsbeautifier/javascript/acorn.py
+++ b/python/jsbeautifier/javascript/acorn.py
@@ -46,34 +46,34 @@ _nonASCIIidentifierChars = six.u(
 _unicodeEscapeOrCodePoint = six.u(r"\\u[0-9a-fA-F]{4}|\\u\{[0-9a-fA-F]+\}")
 
 _identifierStart = (
-    six.u("(?:")
+    "(?:"
     + _unicodeEscapeOrCodePoint
-    + six.u("|[")
+    + "|["
     + _baseASCIIidentifierStartChars
     + _nonASCIIidentifierStartChars
-    + six.u("])")
+    + "])"
 )
 _identifierChars = (
-    six.u("(?:")
+    "(?:"
     + _unicodeEscapeOrCodePoint
-    + six.u("|[")
+    + "|["
     + _baseASCIIidentifierChars
     + _nonASCIIidentifierStartChars
     + _nonASCIIidentifierChars
-    + six.u("])*")
+    + "])*"
 )
 
 identifier = re.compile(_identifierStart + _identifierChars)
 
 identifierStart = re.compile(_identifierStart)
 identifierMatch = re.compile(
-    six.u("(?:")
+    "(?:"
     + _unicodeEscapeOrCodePoint
-    + six.u("|[")
+    + "|["
     + _baseASCIIidentifierChars
     + _nonASCIIidentifierStartChars
     + _nonASCIIidentifierChars
-    + six.u("])+")
+    + "])+"
 )
 
 _nonASCIIwhitespace = re.compile(


### PR DESCRIPTION
Hi,

I think that if project does not support Python2.7 anymore, six should be completely removed.

Let's start

https://wiki.debian.org/Python3-six-removal
