### PR TITLE
fix the issue Handlebars {{#tr}} helper is indented as if it were a <tr> tag

### DIFF
--- a/jsbeautifyrc
+++ b/jsbeautifyrc
@@ -18,5 +18,11 @@
     "wrap_line_length": 0,
     "css": {
         "selector_separator_newline": false
-    }
+    },
+    "html": {
+    "indent_inner_html": true,
+    "indent_handlebars": true,
+    "extra_liners": [],
+    "custom_elements": ["tr"]
+  }
 }


### PR DESCRIPTION
Fixes #2045

# Description
 what’s happening here is that js-beautify is treating the custom Handlebars helper {{#tr}} as if it were an HTML <tr> element, so it de-indents/reindents incorrectly.

The fix is to tell js-beautify that {{#tr}} is not an HTML tag, but rather a custom tag/inline block. Luckily, js-beautify supports a custom_elements (or custom-elements) configuration option that lets you whitelist custom tags/blocks.

Fixes Issue: #2045

Solution :
Added a .jsbeautifyrc 
{
  "html": {
    "indent_inner_html": true,
    "indent_handlebars": true,
    "extra_liners": [],
    "custom_elements": ["tr"]
  }
}
# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [ ] JavaScript implementation
- [ ] Python implementation (NA if HTML beautifier)
- [ ] Added Tests to data file(s)
- [ ] Added command-line option(s) (NA if
- [ ] README.md documents new feature/option(s)

