### PR TITLE
fix: make dark mode label dynamic

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
         <input type="checkbox" id="theme-toggle-btn" style="display: none" />
         <div id="theme-toggle-slider"></div>
       </label>
-      <span>Enable Dark Mode</span>
+      <span id="theme-text">Enable Light Mode</span>
     </div>
     <select name="language" id="language">
       <option value="css">Beautify CSS</option>

--- a/web/common-function.js
+++ b/web/common-function.js
@@ -417,9 +417,13 @@ function switchTheme(themeToggleEvent) {
     $('.CodeMirror').addClass('cm-s-darcula');
     $('body').addClass('dark-mode');
     $('.logo').children('img').attr("src", "web/banner-dark.svg");
+
+    $('#theme-text').text('Enable Light Mode');
   } else {
     $('.CodeMirror').removeClass('cm-s-darcula');
     $('body').removeClass('dark-mode');
     $('.logo').children('img').attr("src", "web/banner-light.svg");
+
+    $('#theme-text').text('Enable Dark Mode');
   }
 }


### PR DESCRIPTION
# Description
- [x] Source branch in your fork has meaningful name (not `main`)

Fixes: #2418

This PR makes the "Enable Dark Mode" label dynamic based on the current theme state.

- Updates the label text when toggling between light and dark mode
- Improves user feedback and UI clarity


# Before Merge Checklist 

(Check any items that are not applicable (NA) for this PR)

- [x] JavaScript implementation
- [x] Python implementation (NA)
- [x] Added Tests to data file(s) (NA)
- [x] Added command-line option(s) (NA)
- [x] README.md documents new feature/option(s) (NA)
